### PR TITLE
FI-2921: Support SQLAlchemy database result backend

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN apk add --no-cache ca-certificates tzdata && update-ca-certificates
 
 # Install the required packages
 RUN pip install --no-cache-dir redis flower
+RUN pip install --no-cache-dir "SQLAlchemy>=1.4,<2" "psycopg2-binary>=2.9,<3"
 
 # PYTHONUNBUFFERED: Force stdin, stdout and stderr to be totally unbuffered. (equivalent to `python -u`)
 # PYTHONHASHSEED: Enable hash randomization (equivalent to `python -R`)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,14 @@ services:
     image: redis:alpine
     ports:
       - 6379:6379
+  postgres:
+    image: postgres:14-alpine
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    ports:
+      - 5432:5432
   prometheus:
     image: prom/prometheus
     volumes:

--- a/flower/utils/results/result.py
+++ b/flower/utils/results/result.py
@@ -58,8 +58,8 @@ class Result:
             "task_id": self.task_id,
             "status": self.status,
             "date_done": self.date_done.timestamp(),
-            "args": repr(self.args),
-            "kwargs": repr(self.kwargs),
+            "args": self.args if isinstance(self.args, str) else repr(self.args),
+            "kwargs": self.kwargs if isinstance(self.kwargs, str) else repr(self.kwargs),
             "result": repr(self.result),
             "traceback": str(self.traceback),
         }

--- a/flower/utils/results/result.py
+++ b/flower/utils/results/result.py
@@ -2,7 +2,7 @@ import datetime
 import heapq
 from collections.abc import Iterator, Iterable
 from functools import total_ordering
-from typing import Any, Sequence, TypeAlias
+from typing import Any, TypeAlias
 
 import dateutil.parser
 import kombu.clocks
@@ -14,12 +14,12 @@ class Result:
         *,
         task_id: str,
         status: str,
-        date_done: str,
+        date_done: str | datetime.datetime,
         result: Any,
         traceback: Any,
         # fields with default values may be null when Celery's `result_extended=False`
-        args: Sequence[Any] | None = None,
-        kwargs: dict[str, Any] | None = None,
+        args: Any = None,
+        kwargs: Any = None,
         name: str | None = None,
         # add graceful handling for extra fields that may have been persisted to the result backend record
         **kw: Any,
@@ -30,7 +30,9 @@ class Result:
         """
         self.task_id = task_id
         self.status = status
-        self.date_done: datetime.datetime = dateutil.parser.parse(date_done)
+        self.date_done: datetime.datetime = (
+            dateutil.parser.parse(date_done) if isinstance(date_done, str) else date_done
+        )
         self.result = result
         self.traceback = traceback
         self.name = name

--- a/flower/utils/results/stores/database.py
+++ b/flower/utils/results/stores/database.py
@@ -1,13 +1,107 @@
+import json
+import pickle
 from collections.abc import Iterator
+from typing import Any
 
-from celery.backends.database import DatabaseBackend
+import kombu.serialization
+import sqlalchemy as sa
+from celery.backends.database import DatabaseBackend, TaskExtended
+from sqlalchemy.orm.session import Session
 
-from flower.utils.results.result import ResultIdWithResultPair
+from flower.utils.results.result import ResultIdWithResultPair, Result
 from flower.utils.results.stores import AbstractBackendResultsStore
 
 
 class DatabaseBackendResultsStore(AbstractBackendResultsStore[DatabaseBackend]):
+    """
+    Results store capable of reading from Celery's supported `DatabaseBackend`, which uses SQLAlchemy models to persist
+    tasks in a SQL database.
+    """
     def results_by_timestamp(self, limit: int | None = None, reverse: bool = True) -> Iterator[
         ResultIdWithResultPair
     ]:
-        raise NotImplementedError()
+        query_limit = self.max_tasks_in_memory
+        if limit is not None and limit < query_limit:
+            query_limit = limit
+
+        session: Session
+        with self.backend.ResultSession() as session:
+            ordering = TaskExtended.date_done.desc() if reverse else TaskExtended.date_done.asc()
+            task_select_query = sa.select(TaskExtended).order_by(ordering).limit(query_limit)
+            for task in session.execute(task_select_query).scalars():
+                result = self._map_task_to_result(task)
+                yield result.task_id, result
+
+    def _map_task_to_result(self, task: TaskExtended) -> Result:
+        """
+        Convert a `TaskExtended` ORM object into our shared `Result` data structure. This class assumes the usage of
+        `TaskExtended` in order to query the "taskmeta" table, since `TaskExtended` queries can successfully return
+        full data for both tasks that were saved with `result_extended=True` and those that were saved with
+        `result_extended=False`.
+
+        Because we want to support both extended and non-extended tasks, we need a way to figure out whether the
+        provided task was _actually_ extended or not at the time it was saved. We can do this by looking at the `name`
+        field. When a task is saved under `result_extended=True`, then it will have a name referencing the name of the
+        function. Otherwise, that field will be null and we know that it was `result_extended=False`.
+        """
+        is_actually_extended: bool = task.name is not None
+        if is_actually_extended:
+            return Result(
+                task_id=task.task_id,
+                status=task.status,
+                date_done=task.date_done,
+                result=task.result,
+                traceback=task.traceback,
+                args=self.deserialize_binary_column_value(task.args),
+                kwargs=self.deserialize_binary_column_value(task.kwargs),
+                name=task.name,
+            )
+
+        return Result(
+            task_id=task.task_id,
+            status=task.status,
+            date_done=task.date_done,
+            result=task.result,
+            traceback=task.traceback,
+        )
+
+    def deserialize_binary_column_value(self, value: bytes) -> Any:
+        """
+        Attempt to deserialize the provided `value` using the available serialization decoders. Celery stores task
+        `args` and `kwargs` in binary columns, but the proper decoding mechanism for those binary columns is not
+        immediately obvious. These fields get serialized bsed on whatever the value of `Celery.conf.result_serializer`
+        is at the time the task result is saved. However, it's possible that the value of that config setting changed
+        across different Celery processes, and therefore we may be dealing with a database that has co-mingled records
+        from different serializers. Unfortunately, there is no column in the database schema that records which
+        serializer was used for each task.
+
+        To work around this limitation, this method takes guesses at the serialization of `value` based on whatever
+        serializers are available in the active `result_accept_content` or `accept_content` Celery config setting.
+        Each serializer will attempt deserialization, and if one succeeds, we return the deserialized value immediately.
+        If all deserialization attempts fail, we will gracefully return the original bytes value.
+
+        TODO: currently this method only attempts deserialization with JSON and pickle. We should support more built-in
+          content types, and potentially allow for deserialization using custom encodings. We chose to limit the
+          supported serializers here because JSON and pickle are the only serialization mechanisms available without
+          additional dependencies (e.g. 'yaml' requires the inclusion of the third-party `yaml` library).
+        """
+        celery_result_accept_content: list[str] = (
+            self.backend.app.conf.result_accept_content
+            or self.backend.app.conf.accept_content
+        )
+        accept_content_types: list[str] = [item.lower() for item in celery_result_accept_content]
+
+        if 'json' in accept_content_types or 'application/json' in accept_content_types:
+            try:
+                return kombu.serialization.registry._decoders['application/json'](value)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                pass
+
+        if 'pickle' in accept_content_types or 'application/x-python-serialize' in accept_content_types:
+            try:
+                return kombu.serialization.registry._decoders['application/x-python-serialize'](value)
+            except pickle.UnpicklingError:
+                pass
+
+        # couldn't deserialize; just fall back to the original byte string
+        return value

--- a/flower/utils/results/stores/database.py
+++ b/flower/utils/results/stores/database.py
@@ -78,7 +78,8 @@ class DatabaseBackendResultsStore(AbstractBackendResultsStore[DatabaseBackend]):
         To work around this limitation, this method takes guesses at the serialization of `value` based on whatever
         serializers are available in the active `result_accept_content` or `accept_content` Celery config setting.
         Each serializer will attempt deserialization, and if one succeeds, we return the deserialized value immediately.
-        If all deserialization attempts fail, we will gracefully return the original bytes value.
+        If all deserialization attempts fail, we will gracefully return the original bytes value with a prefix message
+        explaining that deserialization failed.
 
         TODO: currently this method only attempts deserialization with JSON and pickle. We should support more built-in
           content types, and potentially allow for deserialization using custom encodings. We chose to limit the
@@ -103,5 +104,5 @@ class DatabaseBackendResultsStore(AbstractBackendResultsStore[DatabaseBackend]):
             except pickle.UnpicklingError:
                 pass
 
-        # couldn't deserialize; just fall back to the original byte string
-        return value
+        # couldn't deserialize; just fall back to an error message plus the `repr()` of the original byte string
+        return 'Failed to deserialize binary value: ' + repr(value)

--- a/flower/utils/results/stores/redis.py
+++ b/flower/utils/results/stores/redis.py
@@ -1,4 +1,3 @@
-import json
 from collections.abc import Iterator
 from typing import Any
 
@@ -23,7 +22,7 @@ class RedisBackendResultsStore(AbstractBackendResultsStore[RedisBackend]):
         for key in self.backend.client.scan_iter(
             match=task_key_prefix + ("*" if isinstance(task_key_prefix, str) else b"*")
         ):
-            result_data: dict[str, Any] = json.loads(self.backend.client.get(key))
+            result_data: dict[str, Any] = self.backend.decode_result(self.backend.client.get(key))
             result = Result(**result_data)
             heap.push(result)
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,6 @@
 -r default.txt
 -r test.txt
 redis>=4.3.6
+SQLAlchemy>=1.4,<2
+psycopg2-binary>=2.9,<3
 pylint

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -2,10 +2,13 @@ import os
 import unittest
 from distutils.util import strtobool
 from unittest.mock import patch
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse, urlunparse
 
-import celery
+import celery.backends.database.session
+import sqlalchemy.schema
 import tornado.testing
+from celery.backends.database import DatabaseBackend
+from celery.exceptions import ImproperlyConfigured
 from tornado.ioloop import IOLoop
 from tornado.options import options
 
@@ -60,3 +63,66 @@ class BackendDependentTestCase(unittest.TestCase):
                 '__unittest_skip_why__',
                 f'Skipping this test case due to the "{skip_backend_tests_env_var}" being true',
             )
+
+
+class DatabaseBackendDependentTestCase(BackendDependentTestCase):
+    """
+    Extension of `BackendDependentTestCase` that sets a default value for `self.app.conf.database_url` based on the
+    `TEST_DATABASE_CELERY_RESULT_BACKEND_CONNECTION_STRING` environment variable. If no such environment variable
+    exists, the setup will assume a localhost connection to Postgres.
+    """
+
+    test_schema_name = 'test_flower'
+    """
+    Name of the DB schema within which we should run tests. This should be separate from the main database schema so
+    we are safe to create/destroy records at-will throughout the testing lifecycle.
+    """
+
+    def setUp(self):
+        super().setUp()
+        if hasattr(self, 'app'):
+            if not isinstance(self.app, celery.Celery):
+                raise ImproperlyConfigured(
+                    'If `self.app` is initialized by another class setUp, it must be an instance of Celery'
+                )
+        else:
+            self.app = celery.Celery()
+
+        database_url_parsed = urlparse(
+            os.environ.get(
+                'TEST_DATABASE_CELERY_RESULT_BACKEND_CONNECTION_STRING',
+                'postgresql://postgres:postgres@localhost:5432',
+            )
+        )
+        if '+' in database_url_parsed.scheme:
+            raise ImproperlyConfigured(
+                'Should exclude the "+" from Celery database_url scheme and instead only supply the database protocol'
+            )
+        self.app.conf.database_url = urlunparse(database_url_parsed)
+
+        # restrict creation/deletion of DB models to a separate schema
+        self.app.conf.database_table_schemas = {
+            'task': self.test_schema_name,
+            'group': self.test_schema_name,
+        }
+
+        self.backend = DatabaseBackend(app=self.app)
+        self._ensure_test_schema()
+
+    def _ensure_test_schema(self) -> None:
+        """
+        Create a short-lived session that executes a CREATE SCHEMA statement if the test schema does not yet exist
+        in the database.
+        """
+        test_schema_name = self.test_schema_name
+
+        class CreateSchemaSessionManager(celery.backends.database.session.SessionManager):
+            def prepare_models(self, engine):
+                with engine.connect() as conn:
+                    if not conn.dialect.has_schema(conn, test_schema_name):
+                        engine.execute(sqlalchemy.schema.CreateSchema(test_schema_name))
+                return super().prepare_models(engine)
+
+        with self.backend.ResultSession(session_manager=CreateSchemaSessionManager()):
+            # invoking the context manager will invoke the `prepare_models()` that ensures a schema
+            pass

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -120,7 +120,7 @@ class DatabaseBackendDependentTestCase(BackendDependentTestCase):
             def prepare_models(self, engine):
                 with engine.connect() as conn:
                     if not conn.dialect.has_schema(conn, test_schema_name):
-                        engine.execute(sqlalchemy.schema.CreateSchema(test_schema_name))
+                        conn.execute(sqlalchemy.schema.CreateSchema(test_schema_name))
                 return super().prepare_models(engine)
 
         with self.backend.ResultSession(session_manager=CreateSchemaSessionManager()):

--- a/tests/unit/utils/results/stores/test_database.py
+++ b/tests/unit/utils/results/stores/test_database.py
@@ -1,0 +1,301 @@
+import inspect
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from decimal import Decimal
+from typing import Any, Callable
+
+import celery.app.task
+import kombu.serialization
+import sqlalchemy as sa
+from celery.backends.database import Task, TaskSet, DatabaseBackend
+from sqlalchemy.orm import Session
+
+from flower.utils.results.result import Result, ResultIdWithResultPair
+from flower.utils.results.stores.database import DatabaseBackendResultsStore
+from tests.unit import DatabaseBackendDependentTestCase
+
+
+class TestDatabaseBackendResultsStoreResultsByTimestamp(DatabaseBackendDependentTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self._purge_all_db_results()
+        self.session: Session = self.backend.ResultSession()
+
+        self.task_1_id = 'TASK1-69141a82-d075-44fa-831c-f0ce9b7cd053'
+        self._persist_result(
+            task_id=self.task_1_id,
+            result=None,
+            traceback=None,
+            name='my_module.success_1_task',
+            args=(1, 2),
+            kwargs={'seconds': 2},
+        )
+        time.sleep(0.01)
+        self.task_2_id = 'TASK2-feb138ca-d673-40f2-b6e2-7ad0146b36d5'
+        self._persist_result(
+            task_id=self.task_2_id,
+            result='all good',
+            traceback=None,
+            name=None,
+            args=None,
+            kwargs=None,
+        )
+        time.sleep(0.01)
+        self.task_3_id = 'TASK3-52a34f7d-d0ba-43c9-b13d-14fc5d1c6094'
+        self._persist_result(
+            task_id=self.task_3_id,
+            result=ZeroDivisionError('You cannot divide by zero'),
+            traceback='Traceback (most recent call last): \nOh no, zero division :(',
+            name='another.module.task_3_error_task',
+            args=(1, 'hey'),
+            kwargs={'more': 'stuff'},
+        )
+
+    def tearDown(self):
+        try:
+            super().tearDown()
+            if self.session.in_transaction():
+                self.session.rollback()
+            self.session.close()
+        finally:
+            self._purge_all_db_results()
+
+    def test_results_by_timestamp_is_lazy_generator(self) -> None:
+        results_store = DatabaseBackendResultsStore(backend=self.backend, max_tasks_in_memory=100)
+        self.assertTrue(inspect.isgenerator(results_store.results_by_timestamp()))
+
+    def test_results_by_timestamp_no_limit_reverse_true(self) -> None:
+        results_store = DatabaseBackendResultsStore(backend=self.backend, max_tasks_in_memory=100)
+        result_pairs: list[ResultIdWithResultPair] = list(results_store.results_by_timestamp(limit=None, reverse=True))
+        result_ids: list[str] = [result_tup[0] for result_tup in result_pairs]
+        self.assertEqual(len(result_ids), 3)
+        self.assertEqual(result_ids, [self.task_3_id, self.task_2_id, self.task_1_id])
+        results: list[Result] = [result_tup[1] for result_tup in result_pairs]
+        expected_result_3, expected_result_2, expected_result_1 = results
+        self._assert_is_result_1(expected_result_1)
+        self._assert_is_result_2(expected_result_2)
+        self._assert_is_result_3(expected_result_3)
+
+    def test_results_by_timestamp_no_limit_reverse_false(self) -> None:
+        results_store = DatabaseBackendResultsStore(backend=self.backend, max_tasks_in_memory=100)
+        result_pairs: list[ResultIdWithResultPair] = list(results_store.results_by_timestamp(limit=None, reverse=False))
+        result_ids: list[str] = [result_tup[0] for result_tup in result_pairs]
+        self.assertEqual(len(result_ids), 3)
+        self.assertEqual(result_ids, [self.task_1_id, self.task_2_id, self.task_3_id])
+        results: list[Result] = [result_tup[1] for result_tup in result_pairs]
+        expected_result_1, expected_result_2, expected_result_3 = results
+        self._assert_is_result_1(expected_result_1)
+        self._assert_is_result_2(expected_result_2)
+        self._assert_is_result_3(expected_result_3)
+
+    def test_results_by_timestamp_with_limit_reverse_true(self) -> None:
+        results_store = DatabaseBackendResultsStore(backend=self.backend, max_tasks_in_memory=100)
+        result_pairs: list[ResultIdWithResultPair] = list(results_store.results_by_timestamp(limit=2, reverse=True))
+        result_ids: list[str] = [result_tup[0] for result_tup in result_pairs]
+        self.assertEqual(len(result_ids), 2)
+        self.assertEqual(result_ids, [self.task_3_id, self.task_2_id])
+        results: list[Result] = [result_tup[1] for result_tup in result_pairs]
+        expected_result_3, expected_result_2 = results
+        self._assert_is_result_2(expected_result_2)
+        self._assert_is_result_3(expected_result_3)
+
+    def test_results_by_timestamp_with_limit_reverse_false(self) -> None:
+        results_store = DatabaseBackendResultsStore(backend=self.backend, max_tasks_in_memory=100)
+        result_pairs: list[ResultIdWithResultPair] = list(results_store.results_by_timestamp(limit=2, reverse=False))
+        result_ids: list[str] = [result_tup[0] for result_tup in result_pairs]
+        self.assertEqual(len(result_ids), 2)
+        self.assertEqual(result_ids, [self.task_1_id, self.task_2_id])
+        results: list[Result] = [result_tup[1] for result_tup in result_pairs]
+        expected_result_1, expected_result_2 = results
+        self._assert_is_result_1(expected_result_1)
+        self._assert_is_result_2(expected_result_2)
+
+    def test_max_tasks_in_memory_works_same_as_limit(self) -> None:
+        results_store = DatabaseBackendResultsStore(backend=self.backend, max_tasks_in_memory=1)
+
+        result_pairs_reverse_true: list[ResultIdWithResultPair] = list(
+            results_store.results_by_timestamp(limit=None, reverse=True)
+        )
+        self.assertEqual(len(result_pairs_reverse_true), 1)
+        self.assertEqual(result_pairs_reverse_true[0][0], self.task_3_id)
+        self._assert_is_result_3(result_pairs_reverse_true[0][1])
+
+        result_pairs_reverse_false: list[ResultIdWithResultPair] = list(
+            results_store.results_by_timestamp(limit=None, reverse=False)
+        )
+        self.assertEqual(len(result_pairs_reverse_false), 1)
+        self.assertEqual(result_pairs_reverse_false[0][0], self.task_1_id)
+        self._assert_is_result_1(result_pairs_reverse_false[0][1])
+
+    def test_empty_result_set_when_no_results_present(self) -> None:
+        self._purge_all_db_results()
+        results_store = DatabaseBackendResultsStore(backend=self.backend, max_tasks_in_memory=100)
+        self.assertEqual(list(results_store.results_by_timestamp(limit=None, reverse=True)), [])
+
+    def test_results_are_queryable_in_sqlalchemy(self) -> None:
+        session: Session
+        with self.backend.ResultSession() as session:
+            ids_in_db = list[str](
+                session.execute(sa.select(Task.task_id).order_by(Task.date_done.asc())).scalars()
+            )
+
+        self.assertListEqual(ids_in_db, [self.task_1_id, self.task_2_id, self.task_3_id])
+
+    def _persist_result(
+        self,
+        *,
+        task_id: str,
+        result: Exception | Any,
+        traceback: str | None,
+        name: str | None,
+        args: tuple[Any, ...] | None,
+        kwargs: dict[Any, Any] | None,
+    ) -> None:
+        is_error: bool = isinstance(result, Exception)
+        task_ctx = celery.app.task.Context(
+            id=task_id,
+            task=name,  # gets stored as `name`
+            args=args,
+            kwargs=kwargs,
+            status='FAILURE' if is_error else 'SUCCESS',
+        )
+        should_persist_result_extended: bool = name is not None
+
+        with patch_celery_conf(self.app, 'result_extended', should_persist_result_extended):
+            # The `result_extended` setting gets used during `DatabaseBackend.__init__()`, so if we want to "change"
+            # the value of the setting during the test lifecycle, we need a new instance of `DatabaseBackend` that
+            # has access to the modified `result_extended` value during `__init__()`. We create a throwaway instance
+            # here to save our task using the new setting.
+            tmp_backend = DatabaseBackend(app=self.app)
+            if is_error:
+                tmp_backend.mark_as_failure(
+                    task_id=task_id,
+                    exc=result,
+                    traceback=traceback,
+                    request=task_ctx,
+                )
+            else:
+                tmp_backend.mark_as_done(
+                    task_id=task_id,
+                    result=result,
+                    request=task_ctx,
+                )
+
+    def _assert_is_result_1(self, result: Result) -> None:
+        self.assertEqual(result.task_id, self.task_1_id)
+        self.assertIsNone(result.result)
+        self.assertEqual(result.name, 'my_module.success_1_task')
+        self.assertEqual(result.args, [1, 2])
+        self.assertEqual(result.kwargs, {'seconds': 2})
+        self.assertEqual(result.status, 'SUCCESS')
+        self.assertIsNone(result.traceback)
+        self.assertIs(result.result_extended, True)
+
+    def _assert_is_result_2(self, result: Result) -> None:
+        self.assertEqual(result.task_id, self.task_2_id)
+        self.assertEqual(result.result, 'all good')
+        self.assertIsNone(result.name)
+        self.assertIsNone(result.args)
+        self.assertIsNone(result.kwargs)
+        self.assertEqual(result.status, 'SUCCESS')
+        self.assertIsNone(result.traceback)
+        self.assertIs(result.result_extended, False)
+
+    def _assert_is_result_3(self, result: Result) -> None:
+        self.assertEqual(result.task_id, self.task_3_id)
+        self.assertEqual(
+            result.result,
+            {
+                'exc_message': ('You cannot divide by zero',),
+                'exc_module': 'builtins',
+                'exc_type': 'ZeroDivisionError',
+            },
+        )
+        self.assertEqual(result.name, 'another.module.task_3_error_task')
+        self.assertEqual(result.args, [1, 'hey'])
+        self.assertEqual(result.kwargs, {'more': 'stuff'})
+        self.assertEqual(result.status, 'FAILURE')
+        self.assertEqual(result.traceback, 'Traceback (most recent call last): \nOh no, zero division :(')
+        self.assertIs(result.result_extended, True)
+
+    def _purge_all_db_results(self) -> None:
+        with self.backend.ResultSession() as session:
+            session.execute(sa.delete(Task))
+            session.execute(sa.delete(TaskSet))
+            session.commit()
+
+
+class TestDatabaseBackendResultsStoreDeserializeBinaryColumnValue(DatabaseBackendDependentTestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.app.conf.accept_content = ['json', 'pickle']
+
+        self.actual_args: tuple[Any, ...] = (34, 'hello', Decimal('55.32'))
+        self.actual_kwargs: dict[str, Any] = {'one': 'the thing', 'two': [8, 1290, 4]}
+
+        json_encode: Callable[..., str] = kombu.serialization.registry._encoders['json'].encoder
+        self.json_args: bytes = json_encode(self.actual_args).encode()
+        self.json_kwargs: bytes = json_encode(self.actual_kwargs).encode()
+
+        pickle_encode: Callable[..., bytes] = kombu.serialization.registry._encoders['pickle'].encoder
+        self.pickled_args: bytes = pickle_encode(self.actual_args)
+        self.pickled_kwargs: bytes = pickle_encode(self.actual_kwargs)
+
+        self.results_store = DatabaseBackendResultsStore(backend=self.backend, max_tasks_in_memory=10_000)
+
+    def test_json_and_pickle_both_work_when_both_present(self) -> None:
+        for json_and_pickle_accept in (['json', 'pickle'], ['application/x-python-serialize', 'application/json']):
+            self.app.conf.accept_content = json_and_pickle_accept
+            self.assertEqual(
+                self.results_store.deserialize_binary_column_value(self.json_args),
+                list(self.actual_args),
+            )
+            self.assertEqual(
+                self.results_store.deserialize_binary_column_value(self.json_kwargs),
+                self.actual_kwargs,
+            )
+            self.assertEqual(
+                self.results_store.deserialize_binary_column_value(self.pickled_args),
+                self.actual_args,
+            )
+            self.assertEqual(
+                self.results_store.deserialize_binary_column_value(self.pickled_kwargs),
+                self.actual_kwargs,
+            )
+
+    def test_original_byte_string_returned_when_content_type_missing(self) -> None:
+        self.app.conf.accept_content = ['something_not_known']
+        self.assertIs(
+            self.results_store.deserialize_binary_column_value(self.json_args),
+            self.json_args,
+        )
+        self.assertIs(
+            self.results_store.deserialize_binary_column_value(self.json_kwargs),
+            self.json_kwargs,
+        )
+        self.assertIs(
+            self.results_store.deserialize_binary_column_value(self.pickled_args),
+            self.pickled_args,
+        )
+        self.assertIs(
+            self.results_store.deserialize_binary_column_value(self.pickled_kwargs),
+            self.pickled_kwargs,
+        )
+
+
+@contextmanager
+def patch_celery_conf(app: celery.Celery, conf_setting_name: str, tmp_conf_setting_value: Any) -> Iterator[None]:
+    """
+    Similar to the `mock.patch.object()` context manager, but to be used for the `Celery.conf` object. Because of how
+    `Celery.conf` is implemented, `mock.patch.object()` doesn't work out of the box. This does the exact same thing
+    in a way that is compatible with that config class.
+    """
+    original_value = getattr(app.conf, conf_setting_name)
+    try:
+        setattr(app.conf, conf_setting_name, tmp_conf_setting_value)
+        yield
+    finally:
+        setattr(app.conf, conf_setting_name, original_value)

--- a/tests/unit/utils/results/stores/test_database.py
+++ b/tests/unit/utils/results/stores/test_database.py
@@ -268,21 +268,21 @@ class TestDatabaseBackendResultsStoreDeserializeBinaryColumnValue(DatabaseBacken
 
     def test_original_byte_string_returned_when_content_type_missing(self) -> None:
         self.app.conf.accept_content = ['something_not_known']
-        self.assertIs(
+        self.assertEqual(
             self.results_store.deserialize_binary_column_value(self.json_args),
-            self.json_args,
+            'Failed to deserialize binary value: ' + repr(self.json_args),
         )
-        self.assertIs(
+        self.assertEqual(
             self.results_store.deserialize_binary_column_value(self.json_kwargs),
-            self.json_kwargs,
+            'Failed to deserialize binary value: ' + repr(self.json_kwargs),
         )
-        self.assertIs(
+        self.assertEqual(
             self.results_store.deserialize_binary_column_value(self.pickled_args),
-            self.pickled_args,
+            'Failed to deserialize binary value: ' + repr(self.pickled_args),
         )
-        self.assertIs(
+        self.assertEqual(
             self.results_store.deserialize_binary_column_value(self.pickled_kwargs),
-            self.pickled_kwargs,
+            'Failed to deserialize binary value: ' + repr(self.pickled_kwargs),
         )
 
 


### PR DESCRIPTION
## Change Note(s):

- Support the Celery `DatabaseBackend` (aka SQLAlchemy) when querying for "Results." A [previous PR](https://github.com/shipwell/flower/pull/1) added support for the `RedisBackend` results, however we must support `DatabaseBackend` in order to meet Shipwell use cases. 
- Introduce dev dependency on `SQLAlchemy` and `psycopg2-binary`
- Fix bug in Redis results store where custom data types could not be properly deserialized due to the use of a naive JSON decoder